### PR TITLE
Disable gulp-livereload in production mode

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,7 +18,10 @@ var gulpIf = require('gulp-if');
 var spriteSmithMulti = require('gulp.spritesmith-multi');
 var gmsmith = require('gmsmith');
 var sourcemaps = require('gulp-sourcemaps');
-livereload({start: true});
+
+if(!argv.production) {
+  livereload({start: true});
+}
 
 //fast install
 //npm i --save-dev browserify vinyl-source-stream babelify gulp-livereload gulp gulp-sass


### PR DESCRIPTION
Fix #39 , otherwise the process `npm run gulp -- --production` will not end.