### PR TITLE
Simplify the process of sprite generation

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -193,12 +193,6 @@ function getSpriteStreamFromPngFiles (
     var filesGlobPath = path.join(inputImageDirPath, "/**/*.png"); // Attention!
     console.log("source glob path: " + filesGlobPath);
 
-    var imageFileNamePrefix = outputImageFileNamePrefix;
-    console.log("imageFileNamePrefix: " + imageFileNamePrefix);
-
-    var cssSpritesheetName = cssPrefix;
-    console.log("cssSpritesheetName: " + cssSpritesheetName);
-
     return gulp.src(filesGlobPath)
     .pipe(spriteSmithMulti({
       to: (!generateSplitSprites ? null : function (filePath) {
@@ -206,10 +200,10 @@ function getSpriteStreamFromPngFiles (
             .replace(/[\/\\ ]/g, '-');
       }),
       spritesmith: function (options, sprite, icons) {
-        options.imgName = `${imageFileNamePrefix}-${sprite}.png`; // The format conversion does not work well on macOS.
+        options.imgName = `${outputImageFileNamePrefix}-${sprite}.png`; // The format conversion does not work well on macOS.
         // Don't care about 'cssName', these css files will be concatenated with each other.
-        options.imgPath = `../../public/build/${imageFileNamePrefix}-${sprite}.${outputImageFileFormat}`;
-        options.cssSpritesheetName = `${cssSpritesheetName}-${sprite}`;
+        options.imgPath = `../../public/build/${outputImageFileNamePrefix}-${sprite}.${outputImageFileFormat}`;
+        options.cssSpritesheetName = `${cssPrefix}-${sprite}`;
 
         // Use the default engine 'pixelsmith'.
         // The argument 'options.imgOpts.quality' is unnecessary, because the output images are always PNG files.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -230,6 +230,8 @@ function getSpriteStreamFromPngFiles (
 
         // Use the default engine 'pixelsmith'.
         // The argument 'options.imgOpts.quality' is unnecessary, because the output images are always PNG files.
+
+        return options;
       }
     }));
   });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -220,7 +220,7 @@ function getSpriteStreamFromPngFiles (
       cssSpritesheetName = `${cssPrefix}-${folder}`;
     }
     console.log("cssSpritesheetName: " + cssSpritesheetName);
-    
+
     return gulp.src(filesGlobPath, { read: false /* `gmsmith` doesn't support in-memory content */ })
     .pipe(spriteSmithMulti({
       spritesmith: function (options, sprite, icons) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -183,7 +183,6 @@ function errorHandler (errorMessage) {
 
 // Learned from
 //   https://github.com/gulpjs/gulp/blob/master/docs/recipes/running-task-steps-per-folder.md
-//   https://github.com/google/material-design-icons/pull/757/files?file-filters%5B%5D=.js#diff-ba210a9157252cc983268fdc3aa3ed52
 //
 function getFolders (dirPath) {
   return fs.readdirSync(dirPath)
@@ -221,7 +220,7 @@ function getSpriteStreamFromPngFiles (
     }
     console.log("cssSpritesheetName: " + cssSpritesheetName);
 
-    return gulp.src(filesGlobPath, { read: false /* `gmsmith` doesn't support in-memory content */ })
+    return gulp.src(filesGlobPath)
     .pipe(spriteSmithMulti({
       spritesmith: function (options, sprite, icons) {
         options.imgName = `${imageFileNamePrefix}-${sprite}.png`; // The format conversion does not work well on macOS.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -194,9 +194,9 @@ function getFolders (dirPath) {
 function getSpriteStreamFromPngFiles (
   inputImageDirPath,
   outputStyleFileName,
-  outputImagefileNamePrefix,
+  outputImageFileNamePrefix,
   cssPrefix,
-  outputImagefileFormat,
+  outputImageFileFormat,
   generateSplitSprites
 ) {
   var folders = getFolders(inputImageDirPath);
@@ -208,9 +208,9 @@ function getSpriteStreamFromPngFiles (
     var filesGlobPath = path.join(inputImageDirPath, folder, "/**/*.png"); // Attention!
     console.log("source glob path: " + filesGlobPath);
 
-    var imageFileNamePrefix = outputImagefileNamePrefix;
+    var imageFileNamePrefix = outputImageFileNamePrefix;
     if (generateSplitSprites) {
-      imageFileNamePrefix = `${outputImagefileNamePrefix}-${folder}`;
+      imageFileNamePrefix = `${outputImageFileNamePrefix}-${folder}`;
     }
     console.log("imageFileNamePrefix: " + imageFileNamePrefix);
 
@@ -225,7 +225,7 @@ function getSpriteStreamFromPngFiles (
       spritesmith: function (options, sprite, icons) {
         options.imgName = `${imageFileNamePrefix}-${sprite}.png`; // The format conversion does not work well on macOS.
         // Don't care about 'cssName', these css files will be concatenated with each other.
-        options.imgPath = `../../public/build/${imageFileNamePrefix}-${sprite}.${outputImagefileFormat}`;
+        options.imgPath = `../../public/build/${imageFileNamePrefix}-${sprite}.${outputImageFileFormat}`;
         options.cssSpritesheetName = `${cssSpritesheetName}-${sprite}`;
 
         // Use the default engine 'pixelsmith'.
@@ -245,7 +245,7 @@ function getSpriteStreamFromPngFiles (
       jimp({
         '': {
           quality: jpegSpriteImageQuality,
-          type: outputImagefileFormat
+          type: outputImageFileFormat
         }
       })
   ));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -189,31 +189,27 @@ function getSpriteStreamFromPngFiles (
   outputImageFileFormat,
   generateSplitSprites
 ) {
-  var generateSplits = function () {
-    var filesGlobPath = path.join(inputImageDirPath, "/**/*.png"); // Attention!
-    console.log("source glob path: " + filesGlobPath);
+  var filesGlobPath = path.join(inputImageDirPath, "/**/*.png"); // Attention!
+  console.log("source glob path: " + filesGlobPath);
 
-    return gulp.src(filesGlobPath)
-    .pipe(spriteSmithMulti({
-      to: (!generateSplitSprites ? null : function (filePath) {
-        return path.dirname(path.relative(inputImageDirPath, filePath))
-            .replace(/[\/\\ ]/g, '-');
-      }),
-      spritesmith: function (options, sprite, icons) {
-        options.imgName = `${outputImageFileNamePrefix}-${sprite}.png`; // The format conversion does not work well on macOS.
-        // Don't care about 'cssName', these css files will be concatenated with each other.
-        options.imgPath = `../../public/build/${outputImageFileNamePrefix}-${sprite}.${outputImageFileFormat}`;
-        options.cssSpritesheetName = `${cssPrefix}-${sprite}`;
+  return gulp.src(filesGlobPath)
+  .pipe(spriteSmithMulti({
+    to: (!generateSplitSprites ? null : function (filePath) {
+      return path.dirname(path.relative(inputImageDirPath, filePath))
+          .replace(/[\/\\ ]/g, '-');
+    }),
+    spritesmith: function (options, sprite, icons) {
+      options.imgName = `${outputImageFileNamePrefix}-${sprite}.png`; // The format conversion does not work well on macOS.
+      // Don't care about 'cssName', these css files will be concatenated with each other.
+      options.imgPath = `../../public/build/${outputImageFileNamePrefix}-${sprite}.${outputImageFileFormat}`;
+      options.cssSpritesheetName = `${cssPrefix}-${sprite}`;
 
-        // Use the default engine 'pixelsmith'.
-        // The argument 'options.imgOpts.quality' is unnecessary, because the output images are always PNG files.
+      // Use the default engine 'pixelsmith'.
+      // The argument 'options.imgOpts.quality' is unnecessary, because the output images are always PNG files.
 
-        return options;
-      }
-    }));
-  };
-
-  return generateSplits()
+      return options;
+    }
+  }))
   .pipe(buffer()) // Streaming not supported by gulp-jimp.
   .pipe(gulpIf("*.css",
       cssConcat(


### PR DESCRIPTION
Fix bugs left in the commit 25e3b92f7d975f2ae8c3ca742fda13aaf40c3d76 .

If https://github.com/reducejs/gulp.spritesmith-multi/pull/10 is merged, the function `to` in the options of spriteSmithMulti ([gulp.spritesmith-multi](https://github.com/reducejs/gulp.spritesmith-multi)) can be simplified further.